### PR TITLE
change segment_indicator type to string

### DIFF
--- a/banjo/conf/schema.xml
+++ b/banjo/conf/schema.xml
@@ -223,7 +223,7 @@
    <field name="acquisition_status" type="text_general" indexed="true" stored="true"/>
    <field name="acquisition_category" type="text_general" indexed="true" stored="true"/>
    <field name="status" type="text_general" indexed="true" stored="true"/>
-   <field name="segment_indicator" type="text_general" indexed="true" stored="true"/>
+   <field name="segment_indicator" type="string" indexed="true" stored="true"/>
    <field name="surface" type="text_general" indexed="true" stored="true"/>   
    <field name="carrier_capacity" type="text_general" indexed="true" stored="true"/>
    <field name="reel_size" type="text_general" indexed="true" stored="true"/>


### PR DESCRIPTION
Currently searching for Timed on Timed/Not-Timed(segment_indicator) filter  returns Non-Timed results as well due to tokenising,  I changed the field type to string so it treats the field as a single token, @scoen could you please have a look