### PR TITLE
ms1690: change carrier's type from text_general to string

### DIFF
--- a/banjo/conf/schema.xml
+++ b/banjo/conf/schema.xml
@@ -227,7 +227,7 @@
    <field name="copy_type" type="string" indexed="true" stored="true"/>
    <field name="copy_role" type="string" indexed="true" stored="true"/>
    <field name="copy_index" type="int" indexed="true" stored="true"/>
-   <field name="carrier" type="text_general" indexed="true" stored="true"/>
+   <field name="carrier" type="string" indexed="true" stored="true"/>
    <field name="algorithm" type="text_general" indexed="true" stored="true"/>   
    <field name="carrier_group" type="string" indexed="true" stored="true"/>
    <field name="date_created" type="date" indexed="true" stored="true"/>


### PR DESCRIPTION
@sjacob @scoen 
Carrier facet value is incorrect, breaking 'reel a' into 'reel' and 'a'
http://ourweb.nla.gov.au/apps/jira/browse/DSCS-1690

