### PR TITLE
Add support for running jelly-solr indexes locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-Example jettyctl config:
+## Latest Jelly Solr version : 1.18.0
 
-Latest Jelly Solr version : 1.18.0
+Example jettyctl config:
 
 ```sh
 PORT=10430
@@ -19,6 +19,8 @@ JAVA_OPTS=-server -Xms512m -Xmx512m -XX:NewRatio=3 -XX:SurvivorRatio=4 \
     -Dsolr.install.dir=/apps/${NODE}/ROOT
 ```
 
-To prepare to run these indexes locally on a Mac, run the shell script `local-deploy.sh` (just the once).
 
-To run: `mvn jetty:run-forked -Dhost=.nla.gov.au -Djetty.port=9999`
+#### Local deployment
+1. Run the shell script `local-deploy.sh` one time, to prepare for running these indexes locally on a Mac.
+
+2. To run: `mvn jetty:run-forked -Dhost=.nla.gov.au -Djetty.port=9999`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ JAVA_OPTS=-server -Xms512m -Xmx512m -XX:NewRatio=3 -XX:SurvivorRatio=4 \
 ```
 
 #### Local deployment
-1. Run the shell script `local-deploy.sh` one time, to prepare for running these indexes locally on a Mac.
+1. Run the shell script `local-deploy.sh` one time only (it takes a little time), to prepare for running these indexes locally on a Mac. 
+
 
 2. To run: `mvn jetty:run-forked -Dhost=.nla.gov.au -Djetty.port=9999`
 

--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ JAVA_OPTS=-server -Xms512m -Xmx512m -XX:NewRatio=3 -XX:SurvivorRatio=4 \
     -Dsolr.data.dir=/somplace/somewherexport/solr/${NODE} -Djetty.port=10340 
     -Dsolr.install.dir=/apps/${NODE}/ROOT
 ```
+
+To prepare to run these indexes locally on a Mac, run the shell script `local-deploy.sh` (just the once).
+
+To run: `mvn jetty:run-forked -Dhost=.nla.gov.au -Djetty.port=9999`

--- a/local-deploy.sh
+++ b/local-deploy.sh
@@ -3,6 +3,7 @@
 SOLR_VERSION=6.6.1
 
 curl -O http://archive.apache.org/dist/lucene/solr/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
+TAR=solr-$SOLR_VERSION.tgz
 
 tar -xf $TAR solr-$SOLR_VERSION/dist \
              solr-$SOLR_VERSION/contrib \
@@ -41,3 +42,5 @@ cp resources/web.xml solr-webapp/ROOT/WEB-INF
 # finally, our index configurations
 mkdir solr-webapp/ROOT/WEB-INF/solr
 cp -a resources/solr.xml jelly banjo banjo-jobs solr-webapp/ROOT/WEB-INF/solr
+rm -Rf solr-$SOLR_VERSION
+rm $TAR

--- a/local-deploy.sh
+++ b/local-deploy.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+SOLR_VERSION=6.6.1
+
+curl -O http://archive.apache.org/dist/lucene/solr/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
+
+tar -xf $TAR solr-$SOLR_VERSION/dist \
+             solr-$SOLR_VERSION/contrib \
+             solr-$SOLR_VERSION/server/solr-webapp \
+             solr-$SOLR_VERSION/server/lib/metrics* \
+             solr-$SOLR_VERSION/server/lib/ext \
+             solr-$SOLR_VERSION/server/resources/log4j.properties
+
+mkdir -p solr-webapp/ROOT/WEB-INF/lib
+
+# throw all the jars required in the lib dir
+cp solr-$SOLR_VERSION/contrib/extraction/lib/*.jar solr-webapp/ROOT/WEB-INF/lib
+cp solr-$SOLR_VERSION/contrib/clustering/lib/*.jar solr-webapp/ROOT/WEB-INF/lib
+cp solr-$SOLR_VERSION/contrib/langid/lib/*.jar solr-webapp/ROOT/WEB-INF/lib
+cp solr-$SOLR_VERSION/contrib/velocity/lib/*.jar solr-webapp/ROOT/WEB-INF/lib
+cp solr-$SOLR_VERSION/contrib/analysis-extras/lucene-libs/lucene-analyzers-icu-*.jar solr-webapp/ROOT/WEB-INF/lib
+
+cp solr-$SOLR_VERSION/dist/solr-cell-*.jar solr-webapp/ROOT/WEB-INF/lib
+cp solr-$SOLR_VERSION/dist/solr-clustering-*.jar solr-webapp/ROOT/WEB-INF/lib
+cp solr-$SOLR_VERSION/dist/solr-langid-*.jar solr-webapp/ROOT/WEB-INF/lib
+cp solr-$SOLR_VERSION/dist/solr-velocity-*.jar solr-webapp/ROOT/WEB-INF/lib
+
+cp solr-$SOLR_VERSION/server/lib/*.jar solr-webapp/ROOT/WEB-INF/lib
+cp solr-$SOLR_VERSION/server/lib/ext/*.jar solr-webapp/ROOT/WEB-INF/lib
+
+# bring in the solr web app
+cp -R solr-$SOLR_VERSION/server/solr-webapp/webapp/* solr-webapp/ROOT
+
+
+# pull in the log configuration
+mkdir solr-webapp/ROOT/WEB-INF/classes
+cp solr-$SOLR_VERSION/server/resources/log4j.properties solr-webapp/ROOT/WEB-INF/classes
+
+cp resources/web.xml solr-webapp/ROOT/WEB-INF
+
+# finally, our index configurations
+mkdir solr-webapp/ROOT/WEB-INF/solr
+cp -a resources/solr.xml jelly banjo banjo-jobs solr-webapp/ROOT/WEB-INF/solr

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
           <artifactId>jetty-maven-plugin</artifactId>
           <version>9.4.6.v20170531</version>
           <configuration>
-            <jvmArgs>-server -Xms512m -Xmx512m -XX:NewRatio=3 -XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8 -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:ConcGCThreads=4 -XX:ParallelGCThreads=4 -XX:+CMSScavengeBeforeRemark -XX:PretenureSizeThreshold=64m -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=50 -XX:CMSMaxAbortablePrecleanTime=6000 -XX:+CMSParallelRemarkEnabled -XX:+ParallelRefProcEnabled -Dsolr.solr.home=${project.basedir}/solr-webapp/ROOT/WEB-INF/solr -Dsolr.data.dir=${project.basedir}/solr-webapp/indexes -Dsolr.install.dir=${project.basedir}/solr-webapp/ROOT </jvmArgs>
+            <jvmArgs>-server -Xms512m -Xmx512m -XX:NewRatio=3 -XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8 -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:ConcGCThreads=4 -XX:ParallelGCThreads=4 -XX:+CMSScavengeBeforeRemark -XX:PretenureSizeThreshold=64m -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=50 -XX:CMSMaxAbortablePrecleanTime=6000 -XX:+CMSParallelRemarkEnabled -XX:+ParallelRefProcEnabled -Dsolr.solr.home=${project.basedir}/solr-webapp/ROOT/WEB-INF/solr -Dsolr.data.dir=${project.basedir}/solr-webapp/indexes -Dsolr.install.dir=${project.basedir}/solr-webapp/ROOT -Dsolr.log=${project.basedir}/solr-webapp -Djetty.port=${jetty.port}</jvmArgs>
             <webAppSourceDirectory>${project.basedir}/solr-webapp/ROOT</webAppSourceDirectory>
             <webApp>
               <contextPath>/solr</contextPath>

--- a/pom.xml
+++ b/pom.xml
@@ -7,4 +7,25 @@
 	<packaging>jar</packaging>
 	<version>1.18.0</version>
 	<name>jelly-solr</name>
+
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-maven-plugin</artifactId>
+          <version>9.4.6.v20170531</version>
+          <configuration>
+            <jvmArgs>-server -Xms512m -Xmx512m -XX:NewRatio=3 -XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8 -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:ConcGCThreads=4 -XX:ParallelGCThreads=4 -XX:+CMSScavengeBeforeRemark -XX:PretenureSizeThreshold=64m -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=50 -XX:CMSMaxAbortablePrecleanTime=6000 -XX:+CMSParallelRemarkEnabled -XX:+ParallelRefProcEnabled -Dsolr.solr.home=${project.basedir}/solr-webapp/ROOT/WEB-INF/solr -Dsolr.data.dir=${project.basedir}/solr-webapp/indexes -Dsolr.install.dir=${project.basedir}/solr-webapp/ROOT </jvmArgs>
+            <webAppSourceDirectory>${project.basedir}/solr-webapp/ROOT</webAppSourceDirectory>
+            <webApp>
+              <contextPath>/solr</contextPath>
+              <descriptor>${project.basedir}/solr-webapp/ROOT/WEB-INF/web.xml</descriptor>
+            </webApp>
+            <classesDirectory>${project.basedir}/solr-webapp/ROOT/WEB-INF/lib</classesDirectory>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
+    
+
 </project>


### PR DESCRIPTION
Adds support for running these indexes locally (only tested on Mac) that was previously provided by the `nla/dl-jelly-solr-run` github project.